### PR TITLE
Assorted fixes to pick up right Llama model, run on MacOS

### DIFF
--- a/bin/add_api_portal.sh
+++ b/bin/add_api_portal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Add the API to the API Management Portal
 if [ "$PROJECT_DIR" = "" ]; then
   echo "Error: PROJECT_DIR not set. Please use starter.sh"

--- a/bin/auto_env.sh
+++ b/bin/auto_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # PROJECT_DIR
 if [[ -z "${PROJECT_DIR}" ]]; then
@@ -92,7 +92,7 @@ else
 fi 
 
 # XXXXXX TO REMOVE WHEN PY_OCI_STARTER.PY is done
-if [ -v REPOSITORY_NAME ]; then
+if [[ -n "${REPOSITORY_NAME+defined}" ]]; then
   return
 fi 
 

--- a/bin/build_all.sh
+++ b/bin/build_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" = "" ]; then
   echo "Error: PROJECT_DIR not set. Please use ./starter.sh build"
   exit 1

--- a/bin/build_common.sh
+++ b/bin/build_common.sh
@@ -1,5 +1,5 @@
 # Build_common.sh
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ -z "${BIN_DIR}" ]]; then
   echo "Error: BIN_DIR not set"
   exit 1

--- a/bin/config.sh
+++ b/bin/config.sh
@@ -30,7 +30,7 @@ if declare -p | grep -q "__TO_FILL__"; then
 
   store_env_sh() {
     echo "$1=$2"            
-    sed -i "s&$1=\"__TO_FILL__\"&$1=\"$2\"&" $PROJECT_DIR/env.sh              
+    sed -i "" "s&$1=\"__TO_FILL__\"&$1=\"$2\"&" $PROJECT_DIR/env.sh
     echo "$1 stored in env.sh"            
     echo       
   }

--- a/bin/config.sh
+++ b/bin/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" = "" ]; then
   echo "Error: PROJECT_DIR not set. Please use starter.sh."
   exit 1

--- a/bin/deploy_bastion.sh
+++ b/bin/deploy_bastion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh deploy bastion"
   exit 1

--- a/bin/deploy_compute.sh
+++ b/bin/deploy_compute.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh deploy compute"
   exit 1

--- a/bin/destroy_all.sh
+++ b/bin/destroy_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh destroy"
   exit 1

--- a/bin/devops.sh
+++ b/bin/devops.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh deploy bastion"
   exit 1

--- a/bin/done.sh
+++ b/bin/done.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 

--- a/bin/gen_auth_token.sh
+++ b/bin/gen_auth_token.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh."
   exit 1

--- a/bin/shared_infra_as_code.sh
+++ b/bin/shared_infra_as_code.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # - 2025-06_17 : added Tofu support for LunaLab
 set -e
 

--- a/bin/ssh_bastion.sh
+++ b/bin/ssh_bastion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh ssh bastion"
   exit 1

--- a/bin/ssh_compute.sh
+++ b/bin/ssh_compute.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh ssh compute"
   exit 1

--- a/bin/ssh_db_node.sh
+++ b/bin/ssh_db_node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh ssh db_node"
   exit 1

--- a/bin/start_stop.sh
+++ b/bin/start_stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh terraform apply"
   exit 1

--- a/bin/starter.sh
+++ b/bin/starter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set project_dir and bin_dir when not called from starter.sh
 if [ "$PROJECT_DIR" == "" ]; then

--- a/bin/terraform_apply.sh
+++ b/bin/terraform_apply.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh terraform apply"
   exit 1

--- a/bin/terraform_destroy.sh
+++ b/bin/terraform_destroy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh terraform destroy"
   exit 1

--- a/bin/terraform_plan.sh
+++ b/bin/terraform_plan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh terraform plan"
   exit 1

--- a/bin/tls_dns_create.sh
+++ b/bin/tls_dns_create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh"
   exit 1

--- a/bin/upgrade.sh
+++ b/bin/upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$PROJECT_DIR" == "" ]; then
   echo "ERROR: PROJECT_DIR undefined. Please use starter.sh upgrade"
   exit 1

--- a/ords/ords.sh
+++ b/ords/ords.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 

--- a/ords/src/after_done.sh
+++ b/ords/src/after_done.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export SRC_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export ROOT_DIR=${SRC_DIR%/*}
 cd $ROOT_DIR

--- a/ords/src/db/db_init.sh
+++ b/ords/src/db/db_init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 

--- a/src/after_done.sh
+++ b/src/after_done.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export SRC_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export ROOT_DIR=${SRC_DIR%/*}
 cd $ROOT_DIR

--- a/src/app/build_app.sh
+++ b/src/app/build_app.sh
@@ -23,7 +23,7 @@ if is_deploy_compute; then
 
     # Find the latest Llama model
     oci generative-ai model-collection list-models --compartment-id $TF_VAR_compartment_ocid --all > $TARGET_DIR/genai_models.json 
-    export TF_VAR_genai_meta_model=`cat $TARGET_DIR/genai_models.json | jq -r '.data.items[] | select(.vendor=="meta") | .["display-name"] ' | head -n 1`
+    export TF_VAR_genai_meta_model=$(jq -r '.data.items[]|select(.vendor=="meta" and (.capabilities|index("CHAT")))|.["display-name"]' $TARGET_DIR/genai_models.json | head -n 1)
     echo $TF_VAR_genai_meta_model
 
     file_replace_variables $TARGET_DIR/compute/$APP_DIR/env.sh

--- a/src/app/build_app.sh
+++ b/src/app/build_app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build_app.sh
 #
 # Compute:

--- a/src/app/src/install.sh
+++ b/src/app/src/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 

--- a/src/app/src/start_api_server.sh
+++ b/src/app/src/start_api_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 export PATH=~/.local/bin/:$PATH

--- a/src/app/src/start_react.sh
+++ b/src/app/src/start_react.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 export PATH=~/.local/bin/:$PATH

--- a/src/app/src/start_streamlit.sh
+++ b/src/app/src/start_streamlit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 export PATH=~/.local/bin/:$PATH

--- a/src/before_destroy.sh
+++ b/src/before_destroy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export SRC_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export ROOT_DIR=${SRC_DIR%/*}
 cd $ROOT_DIR

--- a/src/compute/compute_init.sh
+++ b/src/compute/compute_init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # compute_init.sh 
 #
 # Init of a compute
@@ -83,7 +83,7 @@ done
 
 # -- app/start.sh -----------------------------------------------------------
 for APP_DIR in `ls -d app* | sort -g`; do
-  echo "#!/bin/bash" > $APP_DIR/restart.sh 
+  echo "#!/usr/bin/env bash" > $APP_DIR/restart.sh 
   chmod +x $APP_DIR/restart.sh  
   for START_SH in `ls $APP_DIR/start*.sh | sort -g`; do
     echo "-- $START_SH ---------------------------------------"

--- a/src/compute/helper.sh
+++ b/src/compute/helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 

--- a/src/db/db_init.sh
+++ b/src/db/db_init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 

--- a/src/terraform/variable.tf
+++ b/src/terraform/variable.tf
@@ -6,7 +6,14 @@ variable ssh_public_key {}
 variable ssh_private_key {}
 
 # Prefix
-variable prefix { default = "starter" }
+variable prefix {
+  default = "starter"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9]*$", var.prefix))
+    error_message = "The variable value must start with a letter and contain only alphanumeric characters."
+  }
+}
 
 # Java
 variable language { default = "java" }

--- a/starter.sh
+++ b/starter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # starter.sh proxy. Run the real starter.sh 
 # - in $PROJECT_DIR/bin


### PR DESCRIPTION
* The lab as is picked up a Llama `guard` model. We should select only models that can chat.
* The prefix should be validated - I used a custom one that included a dash `-` and it failed (used the prefix because someone already had this livelab in our tenancy and the bucket names collided).
* Assorted fixes to run on MacOS:
  * `sed -i` needs a backup suffix (can be empty)
  * `#!/bin/bash` points to Bash v3, `#!/usr/bin/env bash` will pick up Homebrew's Bash v5. This should be portable.
